### PR TITLE
Exit quietly for recent installations

### DIFF
--- a/bin/nodenv-doctor
+++ b/bin/nodenv-doctor
@@ -63,6 +63,15 @@ if [ "$num_locations" -eq 0 ]; then
       echo "Please refer to https://github.com/nodenv/nodenv#installation"
     fi
   } | indent
+
+  if [ -n "$(find "${NODENV_ROOT:-~/.nodenv}/bin/nodenv" -mmin 1 2>/dev/null)" ]; then
+    printc bright "Recent installation detected.\n"
+    { echo "Complete the installation by configuring your PATH as above,"
+      echo "and re-run nodenv-doctor in a fresh shell."
+    } | indent
+    exit 0
+  fi
+
   exit 1
 elif [ "$num_locations" -eq 1 ]; then
   printc green "%s\n" "$(type -P nodenv)"

--- a/bin/nodenv-doctor
+++ b/bin/nodenv-doctor
@@ -55,7 +55,7 @@ echo -n "Checking for \`nodenv' in PATH: "
 num_locations="$(type -aP nodenv | uniq | wc -l)"
 if [ "$num_locations" -eq 0 ]; then
   printc red "not found\n"
-  { if [ -x ~/.nodenv/bin/nodenv ]; then
+  { if [ -x "${NODENV_ROOT:-~/.nodenv}/bin/nodenv" ]; then
       echo "You seem to have nodenv installed in \`$HOME/.nodenv/bin', but that"
       echo "directory is not present in PATH. Please add it to PATH by configuring"
       echo "your \`~/${bashrc}', \`~/.zshrc', or \`~/.config/fish/config.fish'."


### PR DESCRIPTION
Since nodenv-doctor is run immediately after nodenv-installer, for many 
installations (non homebrew), the doctor will _always_ fail because it's 
still running in a shell that requires PATH to be updated.

Since many users want to use nodenv-installer in an automated/unattended 
fashion, the installer/doctor should exit with a zero status code after a
"successful" installation.

However, the doctor won't consider a missing nodenv PATH to be
"successful", so quandry!

Now, the doctor will attempt to guess that an installation was "recent" but
determining if the nodenv bin was recently modified (< 1min). If so, then
we print an extra little message and exit 0 instead of 1.

closes #8