### PR TITLE
Get shellcheck via npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,11 @@
       "resolved": "https://registry.npmjs.org/brew-publish/-/brew-publish-2.3.1.tgz",
       "integrity": "sha512-JtitWM9jtnQk2gerUbvpiYJqUPYrvU43Wet1FDm9w81nJJO4BLAeVLUTFWQTQkV7QtE3AVO203R/67NeTMxzVw==",
       "dev": true
+    },
+    "shellcheck": {
+      "version": "github:jasonkarns/shellcheck#3264bd4340a00978e9c75a3767508d750bb7fb46",
+      "from": "github:jasonkarns/shellcheck#install-hook",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "bats": "^1.1.0",
     "bats-assert": "github:jasonkarns/bats-assert-1",
     "bats-support": "github:jasonkarns/bats-support",
-    "brew-publish": "^2.3.1"
+    "brew-publish": "^2.3.1",
+    "shellcheck": "github:jasonkarns/shellcheck#install-hook"
   },
   "keywords": [
     "nodenv",


### PR DESCRIPTION
This allows us to get the latest shellcheck without relying on the
version shipped by travis.